### PR TITLE
fixes #1, inconsistent sidebar styles

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,5 +1,5 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>

--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
   <h3 class="sidebar-title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Fixes issue #1 Inconsistent Sidebar Styles. Changes "Archives" section in publify_core/app/views/archives_sidebar/_content.html.erb so that "Archives" title in sidebar displays with monospace style font and respective bullets display as unfilled circles. "Archives" section previously displayed incorrectly because of a typo: class for title was labeled "sidebar_title" when correct class name is "sidebar-bar" (changed underscore to hyphen). Class for bullets was labeled "sidebar_body" when correct class name is "sidebar-body" (changed underscore to hyphen).