### PR TITLE
closes #3, spinner fades out after search

### DIFF
--- a/publify_core/app/views/admin/content/index.js.erb
+++ b/publify_core/app/views/admin/content/index.js.erb
@@ -1,2 +1,2 @@
 $("#articleList").html('<%= raw escape_javascript(render(partial: "article_list", locals: { articles: @articles })) %>');
-$("#spinner").show();
+$("#spinner").fadeOut();


### PR DESCRIPTION
The spinner was being called to show but never hidden. I instead changed this to a fadeOut method, which still doesn't reflect real-time search results but works as a hotfix for the issue.