### PR TITLE
fixes #2 - post tags are shown as "object"

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
fixes https://github.com/sf-wdi-gaia/publify_debugging_lab/issues/2, calls .val() on jQuery object to save value (instead of input object) as tags in save_article_tags() for article_form