### PR TITLE
closes #4, months correctly associate with their articles

### DIFF
--- a/publify_core/app/models/archives_sidebar.rb
+++ b/publify_core/app/models/archives_sidebar.rb
@@ -30,7 +30,7 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i % 12) + 1
+      month = entry.month.to_i
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),


### PR DESCRIPTION
Archives were associating posts with months by using `month = (entry.month.to_i % 12) + 1`

However the way we have months set up is that they run 1-12, not 0-11, so this modulus will cause December to be 0 instead of 12 (which makes the view break!)

The off-by-one error introduced by the addition also causes the months to misalign, so that all posts are cycled forward one month, with December's posts being thrown out of range and never shown. 

I've updated the entry/month calculation to keep in line with our current system:
`month = entry.month.to_i` 