### PR TITLE
closes #5, fixes archives ordering in sidebar

### DIFF
--- a/publify_core/app/models/archives_sidebar.rb
+++ b/publify_core/app/models/archives_sidebar.rb
@@ -39,7 +39,7 @@ class ArchivesSidebar < Sidebar
         article_count: entry.count
       }
     end
-    @archives = @archives.sort_by { |a, b| [a[:year], a[:month]] <=> [b[:year], b[:month]] }
+    @archives = @archives.sort { |a, b| [a[:year], a[:month]] <=> [b[:year], b[:month]] }
   end
 end
 

--- a/publify_core/app/models/archives_sidebar.rb
+++ b/publify_core/app/models/archives_sidebar.rb
@@ -39,6 +39,7 @@ class ArchivesSidebar < Sidebar
         article_count: entry.count
       }
     end
+    @archives = @archives.sort_by { |a, b| [a[:year], a[:month]] <=> [b[:year], b[:month]] }
   end
 end
 


### PR DESCRIPTION
Closes #5 
Sorts the @archives array before it's sent back by using a multi-value comparison, ensuring archives are correctly sorted by year and month starting from January (or the earliest month with posts.)