### PR TITLE
fixes #3 - load spinner does not go away

### DIFF
--- a/publify_core/app/views/admin/content/index.js.erb
+++ b/publify_core/app/views/admin/content/index.js.erb
@@ -1,2 +1,2 @@
 $("#articleList").html('<%= raw escape_javascript(render(partial: "article_list", locals: { articles: @articles })) %>');
-$("#spinner").show();
+$("#spinner").hide();


### PR DESCRIPTION
fixes https://github.com/sf-wdi-gaia/publify_debugging_lab/issues/3, fixes logic to hide spinner instead of show spinner after search result article_list is displayed